### PR TITLE
updated links for new ilwan username

### DIFF
--- a/members.json
+++ b/members.json
@@ -446,9 +446,9 @@
   {
     "name": "ilwan",
     "distro": "arch",
-    "git": "https://github.com/IGaming73/ArchRice",
+    "git": "https://github.com/ilwan07/ArchRice",
     "images": [
-      "https://github.com/IGaming73/ArchRice/blob/main/screenshots/terminals.png"
+      "https://github.com/ilwan07/ArchRice/blob/main/screenshots/terminals.png"
     ]
   },
   {


### PR DESCRIPTION
I just updated the links to my rice since I've changed my github username and I just noticed that it caused an issue on the rice gallery with my rice which is just an empty space, so I made a commit to change my username in the links to the repo and the image.
I don't know if it will automatically update the website, if not then don't bother with this, but if it does then this commit should fix the issue.