### PR TITLE
Fix invalid json in members.json

### DIFF
--- a/members.json
+++ b/members.json
@@ -792,10 +792,10 @@
     "name": ":3",
     "distro": "macos :(",
     "images": [
-      "https://github.com/finnnnnnnnnnnnnnnnn/rice/blob/main/Screenshot%202025-06-22%20at%201.58.04%E2%80%AFPM.png?raw=true",
+      "https://github.com/finnnnnnnnnnnnnnnnn/rice/blob/main/Screenshot%202025-06-22%20at%201.58.04%E2%80%AFPM.png?raw=true"
     ],
-    "version": 2
-    "git": "https://github.com/finnnnnnnnnnnnnnnnn/rice",
+    "version": 2,
+    "git": "https://github.com/finnnnnnnnnnnnnnnnn/rice"
   }, {
     "name": "askiiart",
     "distro": "fedora",
@@ -859,7 +859,7 @@
 }, {
     "name": "Some1's Hyprland Rice",
     "distro": "Arch",
-    "git": "https://github.com/x-9917638/dotfiles"
+    "git": "https://github.com/x-9917638/dotfiles",
     "images": [
       "https://raw.githubusercontent.com/x-9917638/dotfiles/refs/heads/main/.dotfiles/Assets/Screenshot1.png",
       "https://raw.githubusercontent.com/x-9917638/dotfiles/refs/heads/main/.dotfiles/Assets/Screenshot2.png",


### PR DESCRIPTION
It seems some people made little mistakes while editing members.json, causing the [gallery](https://riceathon.hackclub.com/gallery) to be unable to load.
These changes fix the errors, and the gallery should be able to work again.